### PR TITLE
v2 Devfiles related changes

### DIFF
--- a/documentation/modules/ROOT/pages/02-codeready.adoc
+++ b/documentation/modules/ROOT/pages/02-codeready.adoc
@@ -20,20 +20,20 @@ and getting familiar with the OpenShift CLI and OpenShift Web Console.
 [window=_blank, align="center"]
 image::dev-spaces-graphic.png[OpenShift Dev Spaces, 400]
 
-https://access.redhat.com/products/red-hat-openshift-dev-spaces[OpenShift Dev Spaces^] is a Kubernetes-native IDE and developer collaboration platform.
+https://access.redhat.com/products/red-hat-openshift-dev-spaces[OpenShift Dev Spaces^] is service to start remote, container-based, development environments on Red Hat OpenShift.
 
 As an open-source project, the core goals of https://access.redhat.com/products/red-hat-openshift-dev-spaces[OpenShift Dev Spaces^]  are to:
 
-* **Accelerate project and developer onboarding:** As a zero-install development environment that runs in your browser, https://access.redhat.com/products/red-hat-openshift-dev-spaces[OpenShift Dev Spaces^]  makes it easy for anyone to join your team and contribute to a project.
+* **Accelerate project and developer onboarding:** As a zero-install development environment that runs in your browser, https://access.redhat.com/products/red-hat-openshift-dev-spaces[OpenShift Dev Spaces^] makes it easy for anyone to join your team and contribute to a project.
 * **Remove inconsistency between developer environments:** No more: “But it works on my machine.” Your code works exactly the same way in everyone’s environment.
 * **Provide built-in security and enterprise readiness:** As https://access.redhat.com/products/red-hat-openshift-dev-spaces[OpenShift Dev Spaces^]  becomes a viable replacement for VDI solutions, it must be secure and it must support enterprise requirements, such as role-based access control and the ability to remove all source code from developer machines.
 
 To achieve those core goals, https://access.redhat.com/products/red-hat-openshift-dev-spaces[OpenShift Dev Spaces^]  provides:
 
 * **Workspaces:** Container-based developer workspaces providing all the tools and dependencies needed to code, build, test, run, and debug applications.
-* **Browser-based IDEs:** Bundled browser-based IDEs with language tooling, debuggers, terminal, source control (SCM) integration, and much more.
-* **Extensible platform:** Bring your own IDE. Define, configure, and extend the tools that you need for your application by using plug-ins, which are compatible with Visual Studio Code extensions.
-* **Enterprise Integration:** Multi-user capabilities, including Keycloak for authentication and integration with LDAP or AD.
+* **Browser-based IDEs:** Bundled browser-based IDEs with language tooling, debuggers, terminal, source control (SCM) integration, and much more. Bundled IDEs are Eclipse Theia, Visual Studio Code and IntelliJ.
+* **Extensible platform:** Bring your own IDE. Define, configure, and extend the tools that you need for your application by using custom container images and installing IDE extensions.
+* **Enterprise Integration:** Multi-user capabilities (including Keycloak for authentication and integration with LDAP or AD) and restricted network support (including enteprise SSL certificate bundles and internal proxies).
 --
 
 [#get_your_developer_workspace]
@@ -46,11 +46,8 @@ https://access.redhat.com/products/red-hat-openshift-dev-spaces[OpenShift Dev Sp
 ====
 https://access.redhat.com/products/red-hat-openshift-dev-spaces[OpenShift Dev Spaces^] uses https://devfile.io/docs/2.1.0/what-is-a-devfile[Devfiles^] to automate the provisioning of a specific workspace by defining:
 
-* projects to clone
-* browser IDE to use
-* preconfigured commands
-* tools that you need
 * application runtime definition
+* preconfigured commands
 
 Providing a devfile.yaml file inside a Git source repository signals to https://access.redhat.com/products/red-hat-openshift-dev-spaces[OpenShift Dev Spaces^] to configure the project and runtime according
 to this file.


### PR DESCRIPTION
Proposing some changes to reflect that:

- Dev Spaces provisions IDEs but it's not an IDE itself. The IDE provisioned by Dev Spaces are VS Code and IntelliJ (and currently Theia, but we stop supporting it by the end of 2022).
- In Devfile v2 we don't specify the IDE anymore: the same devfile works with any IDE, to use an IDE different from the default use the `che-editor` URL parameter or the file `.che/che-editor.yaml`
- In Devfile v2 we don't specify plugins anymore: plugins are IDE dependent, VS Code extensions can be specified in `.vscode/extensions.json`
- We want to deprecate `projects` in devfile as we want users to add the devfile in the project git repository itself 
- A devfile is not required to start a Dev Spaces workspace anymore: if no devfile is found a default setup will be used.